### PR TITLE
fix: add none-parameter exception case

### DIFF
--- a/src/spaceone/monitoring/error/event.py
+++ b/src/spaceone/monitoring/error/event.py
@@ -2,7 +2,7 @@ from spaceone.core.error import *
 
 
 class ERROR_REQUIRED_FIELDS(ERROR_BASE):
-    _message = 'Required field is missing(field=})'
+    _message = 'Required field is missing(field= {field})'
 
 
 class ERROR_CHECK_VALIDITY(ERROR_BASE):

--- a/src/spaceone/monitoring/manager/event_manager.py
+++ b/src/spaceone/monitoring/manager/event_manager.py
@@ -51,10 +51,10 @@ class EventManager(BaseManager):
 
     @staticmethod
     def _generate_event_key(raw_data):
-        dashboard_id = raw_data.get('dashboardId')
-        panel_id = raw_data.get('panelId')
-        rule_id = raw_data.get('ruleId')
-        org_id = raw_data.get('orgId')
+        dashboard_id = raw_data.get('dashboardId', '')
+        panel_id = raw_data.get('panelId', '')
+        rule_id = raw_data.get('ruleId', '')
+        org_id = raw_data.get('orgId', '')
 
         if dashboard_id is None:
             raise ERROR_REQUIRED_FIELDS(field='dashboard_id')

--- a/test/api/test_event_api.py
+++ b/test/api/test_event_api.py
@@ -213,16 +213,27 @@ class TestEvent(TestCase):
                     "panelId": 16.0
                 }
         }
+        params8 = {
+            'options': {},
+            'data': {
+
+                    "occured_at": "2021-08-23T06:47:42.759Z",
+                    "description": "마이데이타 포탈 테스트의CPU 현재 주의 상태",
+                    "title": "(주의 알림)마이데이타 포탈 테스트/CPU",
+                    "event_type": "ALERT",
+                    "severity": "ALERT",
+                    "alert_id": "alert-f81100e73c00"
+                }
+            }
 
         #params1, params2, params3, params4,
-        test_cases = [params1, params2, params3, params4, params5, params6, params7]
+        test_cases = [params8]
 
         for idx, test_case in enumerate(test_cases):
             print(f'###### {idx} ########')
             data = test_case.get('data')
             parsed_data = self.monitoring.Event.parse({'options': {}, 'data': data})
-            print_json(parsed_data)
-            print()
+            print(parsed_data)
 
 
 


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
원래 dashboardId, orgId 같은 파라미터들이 None인 경우는 제외해 문제가 되었던 부분의 bug-fix입니다.

원인은 그라파나 raw data의 parameter가 비어있는 상황에서 에러를 raise할때 해당 parameter(dashboardId, orgId.. 등) 를 field로 raise해서, core의 _check_error 부분에서 에러라이징을 한 것입니다. 

parameter들이 누락되더라도 에러를 raise 하지 않도록, get('param', ' ') 로 처리했습니다.

### Known issue

